### PR TITLE
Update syntax to create a WP_Widget object to avoid PHP deprecated wa…

### DIFF
--- a/inc/popular-posts-widget.php
+++ b/inc/popular-posts-widget.php
@@ -16,7 +16,7 @@ class dazzling_popular_posts_widget extends WP_Widget {
 		$control_ops = array( 'width' => 250, 'height' => 350, 'id_base' => 'dazzling_tabbed_widget' );
 
 		/* Create the widget. */
-		$this->WP_Widget( 'dazzling_tabbed_widget', __( 'Dazzling Popular Posts Widget', 'dazzling' ), $widget_ops, $control_ops );
+		WP_Widget::__construct('dazzling_tabbed_widget', __('Dazzling Popular Posts Widget', 'dazzling'), $widget_ops, $control_ops);
 	}
 
 	/**


### PR DESCRIPTION
…rnings from Wordpress core

The use of $this->WP_Widget ends in a warning, because there is a WP_Widget method, that helps PHP 4 to call the contstuctor that is marked as deprecated since Wordpress 4.3.0. Hope this methode will be deleted soon! 
$this->WP_Widget would normally call the _constructor methode of the class, if there wasn't this PHP 4 helper method named exactly as the class. If the WP_Widget method will be deleted, switch back to $this->WP_Widget.
It's a Wordpress error, that I reported to them too, but please change to avoid problem til they changed it. Thx!
